### PR TITLE
Better error when API key is not set

### DIFF
--- a/lib/mailerlite/connection.rb
+++ b/lib/mailerlite/connection.rb
@@ -37,7 +37,7 @@ module MailerLite
       response = connection.send(method) do |request|
         request.url(path, query_params)
         request.headers['Content-Type'] = 'application/json'
-        request.headers['X-MailerLite-ApiKey'] = client.config.api_key
+        request.headers['X-MailerLite-ApiKey'] = client.config.api_key if client.config.api_key
         request.body = body_params.to_json
       end
 


### PR DESCRIPTION
If API key is not set client fails in the depths of `net/http` with cryptic error message (`Method 'strip' not found for 'nil'`), I think it's better to fail with 403 or whatever mailer lite API returns for unauthorized request.