### PR TITLE
Escape emails when unsubscribing from groups

### DIFF
--- a/lib/mailerlite/clients/groups.rb
+++ b/lib/mailerlite/clients/groups.rb
@@ -96,8 +96,9 @@ module MailerLite
       #
       # @return [Hash] Response from API.
       def delete_group_subscriber(group_id, subscriber_id_or_email)
+        escaped_subscriber_id_or_email = CGI.escape(subscriber_id_or_email)
         connection.delete(
-          "groups/#{group_id}/subscribers/#{subscriber_id_or_email}"
+          "groups/#{group_id}/subscribers/#{escaped_subscriber_id_or_email}"
         )
       end
     end

--- a/spec/mailerlite/clients/groups_spec.rb
+++ b/spec/mailerlite/clients/groups_spec.rb
@@ -143,5 +143,12 @@ describe MailerLite::Clients::Groups do
     it 'has correct response' do
       expect(response).to eq({})
     end
+
+    it 'will escape the email' do
+      expect(client.connection)
+        .to receive(:delete)
+        .with('groups/1/subscribers/google%2Bstyle%40mailerlite.com').once
+      client.delete_group_subscriber(1, 'google+style@mailerlite.com')
+    end
   end
 end


### PR DESCRIPTION
Fixes #6 

When unsubscribing an email from a group, the email is passed as part of the URL. Escaping the email before making the request lets us unsubscribe google-style emails `hello+world@sendowl.com`.